### PR TITLE
Allow installation on ARM64

### DIFF
--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -14,6 +14,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
I added an ARM64 installation target to the vsix manifest. I confirmed that it works on a Parallels Windows 11 VM.